### PR TITLE
Improvements for CRC and Path Handling

### DIFF
--- a/splituapp
+++ b/splituapp
@@ -16,9 +16,9 @@ import struct
 from subprocess import check_output
 
 def extract(source, flist):
-	def cmd(command):
+	def cmd(command, argument):
 		try:
-			test1 = check_output(command)
+			test1 = check_output([command, argument])
 			test1 = test1.strip().decode()
 		except:
 			test1 = ''
@@ -99,11 +99,15 @@ def extract(source, flist):
 								crcval.append('%02X' % i)
 
 						crcval = ''.join(crcval)
-						crcact = cmd('./crc output/'+filename+'.img')
+
+						crcact = cmd('./crc', 'output/'+filename+'.img')
 
 						if crcval != crcact:
 							print('ERROR: crc value for '+filename+'.img does not match\n')
-							return 1
+
+						# Do not exit here because CRC check for system.img always fails with
+						# ERROR: Unable to open file system.img
+						# Probably because of filesize.
 			else:
 				f.seek(filesize, 1)
 

--- a/splituapp
+++ b/splituapp
@@ -15,7 +15,7 @@ import string
 import struct
 from subprocess import check_output
 
-def extract(source, flist):
+def extract(source, output, flist, skipcrc, crcpath):
 	def cmd(command, argument):
 		try:
 			test1 = check_output([command, argument])
@@ -26,7 +26,7 @@ def extract(source, flist):
 		return test1
 
 	bytenum = 4
-	outdir = 'output'
+	outdir = output
 	img_files = []
 
 	try:
@@ -64,16 +64,19 @@ def extract(source, flist):
 			f.seek(22, 1)
 			crcdata = f.read(headersize - 98)
 
+			img = filename + '.img'
+			img_path = os.path.join(output, img)
+
 			if not flist or filename in flist:
 				if filename in img_files:
 					filename = filename+'_2'
 
-				print('Extracting '+filename+'.img ...')
+				print('Extracting '+ img)
 
 				chunk = 10240
 
 				try:
-					with open(outdir+os.sep+filename+'.img', 'wb') as o:
+					with open(img_path, 'wb') as o:
 						while filesize > 0:
 							if chunk > filesize:
 								chunk = filesize
@@ -81,14 +84,14 @@ def extract(source, flist):
 							o.write(f.read(chunk))
 							filesize -= chunk
 				except:
-					print('ERROR: Failed to create '+filename+'.img\n')
+					print('ERROR: Failed to create ' + img +'\n')
 					return 1
 
 				img_files.append(filename)
 
 				if os.name != 'nt':
-					if os.path.isfile('crc'):
-						print('Calculating crc value for '+filename+'.img ...\n')
+					if os.path.isfile(crcpath) and not skipcrc:
+						print('Calculating crc value for ' + img)
 
 						crcval = []
 						if py2:
@@ -100,14 +103,10 @@ def extract(source, flist):
 
 						crcval = ''.join(crcval)
 
-						crcact = cmd('./crc', 'output/'+filename+'.img')
+						crcact = cmd(crcpath, os.path.realpath(img_path))
 
 						if crcval != crcact:
-							print('ERROR: crc value for '+filename+'.img does not match\n')
-
-						# Do not exit here because CRC check for system.img always fails with
-						# ERROR: Unable to open file system.img
-						# Probably because of filesize.
+							print('ERROR: CRC for ' + img + '\n')
 			else:
 				f.seek(filesize, 1)
 
@@ -127,6 +126,15 @@ if __name__ == '__main__':
 	optional = parser.add_argument_group('Optional')
 	optional.add_argument("-h", "--help", action="help", help="show this help message and exit")
 	optional.add_argument("-l", "--list", nargs="*", metavar=('img1', 'img2'), help="List of img files to extract")
+	optional.add_argument("-o", "--output", action="store", help="Put output in the given folder")
+	optional.add_argument("-s", "--skip-crc", dest="skip_crc", action="store_true", default=False, help="Do not compute and compare CRC")
 	args = parser.parse_args()
 
-	extract(args.filename, args.list)
+	splituapp_path = os.path.realpath(__file__)
+	crc_path = os.path.join(os.path.dirname(splituapp_path), "crc")
+
+	output_path = "output"
+	if (args.output != None):
+		output = args.output
+
+	extract(args.filename, output, args.list, args.skip_crc, crc_path)


### PR DESCRIPTION
Hi,

your script helped me to work with some old Huawei Update images. Thanks a lot. But since I had some issues I made the following changes:

- Make sure CRC works with Python 2.7 on Ubuntu 20.04.
- Add command line arguments for output and to skip CRC.
- Do not require to run splituapp from the current directory to allow symlinks.